### PR TITLE
feat: add try_entry/clear, parking_lot shard locks, dedup internals, CI lint + full Miri

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,23 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        components: rustfmt, clippy
+
+    - name: Check formatting
+      run: cargo fmt --all --check
+
+    - name: Clippy
+      run: cargo clippy --all-targets -- -D warnings
+
   test:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
@@ -82,4 +99,4 @@ jobs:
           components: miri
 
       - name: Run Miri tests
-        run: cargo miri test lockmap::tests
+        run: cargo miri test --lib

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Add non-blocking `try_entry` / `try_entry_by_ref` to `LockMap` and `LruLockMap`
+- Add `clear` to `LockMap` and `LruLockMap`
+
+### Changed
+
+- Use `parking_lot::Mutex` for internal shard locks. This removes lock poisoning:
+  previously, a panic inside `V::clone()` during `get()` poisoned the shard and made
+  all subsequent operations on that shard panic
+- Check reference-count overflow with `debug_assert` in debug builds
+
+### Internal
+
+- Deduplicate shared internals (`StateFlags`, shard sizing, guard release logic)
+- Attach README doctests via the `#[cfg(doctest)]` idiom instead of a private module
+- Declare `rust-version` (MSRV 1.75) and crates.io `keywords` / `categories` metadata
+- Pin dev-dependency versions (`criterion = "0.8"`, `rand = "0.10"`)
+
+### CI
+
+- Run Miri on the whole library test suite (`cargo miri test --lib`)
+- Add a lint job enforcing `cargo fmt --check` and `cargo clippy -- -D warnings`
+
 ## [0.2.2] - 2026-04-27
 
 ### Added
@@ -31,6 +57,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Breaking:** Consolidate workspace into a single crate; migrate to `parking_lot` mutex and `HashTable`-based `LockMap` with a unified `Entry` API (#30)
+
+  Migration guide:
+
+  | 0.1.x | 0.2.0 |
+  |-------|-------|
+  | `use lockmap::EntryByVal` | `use lockmap::Entry` |
+  | `use lockmap::EntryByRef` | `use lockmap::Entry` |
+  | `use lockmap_lru::LruLockMap` | `use lockmap::LruLockMap` |
+  | `use lockmap_lru::LruEntry` | `use lockmap::LruEntry` |
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,12 +2,16 @@
 name = "lockmap"
 version = "0.2.2"
 edition = "2021"
+rust-version = "1.75"
 
 authors = ["SF-Zhou <sfzhou.scut@gmail.com>"]
 homepage = "https://github.com/SF-Zhou/lockmap"
 repository = "https://github.com/SF-Zhou/lockmap"
 description = "A high-performance, thread-safe HashMap and LRU cache with fine-grained per-key locking."
 license = "MIT OR Apache-2.0"
+readme = "README.md"
+keywords = ["hashmap", "concurrent", "lru", "cache", "lock"]
+categories = ["concurrency", "data-structures", "caching"]
 
 [dependencies]
 aliasable = "0.1"
@@ -16,8 +20,8 @@ hashbrown = "0.15"
 parking_lot = "0.12"
 
 [dev-dependencies]
-criterion = "0"
-rand = "0"
+criterion = "0.8"
+rand = "0.10"
 
 [[bench]]
 name = "bench_lockmap"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Unlike standard concurrent maps that might lock the entire map or large buckets,
 *   **Key-Level Locking**: Acquire exclusive locks for specific keys. Operations on different keys run in parallel.
 *   **Sharding Architecture**: Internal sharding reduces contention on the map structure itself during insertions and removals.
 *   **Deadlock Prevention**: Provides `batch_lock` to safely acquire locks on multiple keys simultaneously using a deterministic order.
+*   **Non-Blocking Locking**: `try_entry` / `try_entry_by_ref` return `None` instead of blocking when a key is already held.
 *   **Single Hash Computation**: Each key is hashed once; the pre-computed hash is stored alongside the key and reused for shard selection, table probing, and rehashing.
 *   **No Key Duplication**: Uses `hashbrown::HashTable` so each key is stored only once, inside the entry state.
 *   **Entry API**: Ergonomic unified RAII guard (`Entry`) for managing locks.
@@ -58,10 +59,15 @@ assert_eq!(map.get("key"), Some("value".into()));
     entry.insert("new value".to_string());
 } // Lock is automatically released here
 
-// 4. Remove a value
-assert_eq!(map.remove("key"), Some("new value".into()));
+// 4. Non-blocking access: returns None if the key is currently held
+if let Some(mut entry) = map.try_entry_by_ref("key") {
+    entry.insert("another value".to_string());
+}
 
-// 5. Batch Locking (Deadlock safe)
+// 5. Remove a value
+assert_eq!(map.remove("key"), Some("another value".into()));
+
+// 6. Batch Locking (Deadlock safe)
 // Acquires locks for multiple keys in a deterministic order.
 let mut keys = BTreeSet::new();
 keys.insert("key1".to_string());
@@ -74,6 +80,11 @@ if let Some(entry) = locked_entries.get_mut("key1") {
    entry.insert("updated_in_batch".into());
 }
 // All locks released when `locked_entries` is dropped
+drop(locked_entries);
+
+// 7. Clear the map (waits for held entries, like `remove`)
+map.clear();
+assert!(map.is_empty());
 ```
 
 ## LruLockMap
@@ -128,28 +139,7 @@ The `map.get(key)` method clones the value while holding an internal shard lock.
 
 ## Changelog
 
-### 0.2.0
-
-This is a major restructuring release. The previous workspace of three crates (`lockmap`, `lockmap-lru`, `lockmap-core`) has been consolidated into a single `lockmap` crate.
-
-#### Breaking Changes
-
-*   **Unified crate**: `lockmap-lru` and `lockmap-core` no longer exist as separate crates. Import both `LockMap` and `LruLockMap` from `lockmap`:
-    ```rust
-    use lockmap::{LockMap, LruLockMap};
-    ```
-*   **Unified `Entry` type**: The separate `EntryByVal` and `EntryByRef` types in `LockMap` have been replaced by a single [`Entry`](https://docs.rs/lockmap/latest/lockmap/struct.Entry.html) type. The key is now stored inside the entry state and accessed via `entry.key()`.
-*   **`parking_lot` mutex**: The custom futex-based mutex and `atomic-wait` dependency have been replaced by `parking_lot::RawMutex`.
-*   **`HashTable` storage for `LockMap`**: `LockMap` now uses `hashbrown::HashTable` (like `LruLockMap`) with the key and pre-computed hash stored in the entry state. Each operation hashes the key only once.
-
-#### Migration Guide
-
-| 0.1.x | 0.2.0 |
-|-------|-------|
-| `use lockmap::EntryByVal` | `use lockmap::Entry` |
-| `use lockmap::EntryByRef` | `use lockmap::Entry` |
-| `use lockmap_lru::LruLockMap` | `use lockmap::LruLockMap` |
-| `use lockmap_lru::LruEntry` | `use lockmap::LruEntry` |
+See [CHANGELOG.md](CHANGELOG.md) for release notes and migration guides.
 
 ## License
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,0 +1,42 @@
+//! Internal helpers shared by [`LockMap`](crate::LockMap) and
+//! [`LruLockMap`](crate::LruLockMap).
+
+use std::sync::OnceLock;
+
+/// Packed per-key state: the highest bit records whether the entry currently
+/// holds a value, the remaining 31 bits hold the guard reference count.
+pub(crate) struct StateFlags(pub(crate) u32);
+
+impl StateFlags {
+    pub(crate) const HAS_VALUE_FLAG: u32 = 1 << 31;
+    pub(crate) const REFCNT_MASK: u32 = !Self::HAS_VALUE_FLAG;
+
+    pub(crate) fn new(refcnt: u32, has_value: bool) -> Self {
+        let mut val = refcnt & Self::REFCNT_MASK;
+        if has_value {
+            val |= Self::HAS_VALUE_FLAG;
+        }
+        Self(val)
+    }
+
+    pub(crate) fn refcnt(&self) -> u32 {
+        self.0 & Self::REFCNT_MASK
+    }
+
+    pub(crate) fn has_value(&self) -> bool {
+        (self.0 & Self::HAS_VALUE_FLAG) != 0
+    }
+
+    pub(crate) fn pending_cleanup(&self) -> bool {
+        self.0 == 0
+    }
+}
+
+/// Default number of shards: `4 * available_parallelism`, rounded up to the
+/// next power of two. Computed once and cached.
+pub(crate) fn default_shard_amount() -> usize {
+    static DEFAULT_SHARD_AMOUNT: OnceLock<usize> = OnceLock::new();
+    *DEFAULT_SHARD_AMOUNT.get_or_init(|| {
+        (std::thread::available_parallelism().map_or(1, usize::from) * 4).next_power_of_two()
+    })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@
 //! - **Single hash computation**: Key and pre-computed hash stored together; each operation hashes once
 //! - **No key duplication**: Uses [`hashbrown::HashTable`] so each key is stored only once
 //! - **Deadlock prevention**: `LockMap` provides [`batch_lock`](LockMap::batch_lock) for safe multi-key locking
+//! - **Non-blocking locking**: [`try_entry`](LockMap::try_entry) returns `None` instead of blocking when a key is held
 //! - **LRU eviction**: `LruLockMap` automatically evicts least recently used entries when capacity is exceeded
 //! - **Non-blocking eviction**: In-use entries are skipped during eviction; traversal continues to the next candidate
 //!
@@ -59,9 +60,14 @@
 //! assert_eq!(cache.remove("key"), Some(42));
 //! ```
 
-#[doc = include_str!("../README.md")]
+mod common;
 mod lockmap;
 mod lru_lockmap;
 
 pub use lockmap::{Entry, LockMap};
 pub use lru_lockmap::{LruEntry, LruLockMap};
+
+/// Runs the code examples in `README.md` as documentation tests.
+#[cfg(doctest)]
+#[doc = include_str!("../README.md")]
+pub struct ReadmeDoctests;

--- a/src/lockmap.rs
+++ b/src/lockmap.rs
@@ -1,46 +1,15 @@
+use crate::common::{default_shard_amount, StateFlags};
 use aliasable::boxed::AliasableBox;
 use foldhash::fast::RandomState;
 use hashbrown::hash_table::Entry as TableEntry;
 use hashbrown::HashTable;
 use parking_lot::lock_api::RawMutex as _;
-use parking_lot::RawMutex;
+use parking_lot::{Mutex, RawMutex};
 use std::borrow::Borrow;
 use std::cell::UnsafeCell;
 use std::collections::BTreeSet;
 use std::hash::{BuildHasher, Hash};
 use std::sync::atomic::{AtomicU32, Ordering};
-use std::sync::OnceLock;
-
-// ---------------------------------------------------------------------------
-// StateFlags
-// ---------------------------------------------------------------------------
-
-struct StateFlags(u32);
-
-impl StateFlags {
-    const HAS_VALUE_FLAG: u32 = 1 << 31;
-    const REFCNT_MASK: u32 = !Self::HAS_VALUE_FLAG;
-
-    fn new(refcnt: u32, has_value: bool) -> Self {
-        let mut val = refcnt & Self::REFCNT_MASK;
-        if has_value {
-            val |= Self::HAS_VALUE_FLAG;
-        }
-        Self(val)
-    }
-
-    fn refcnt(&self) -> u32 {
-        self.0 & Self::REFCNT_MASK
-    }
-
-    fn has_value(&self) -> bool {
-        (self.0 & Self::HAS_VALUE_FLAG) != 0
-    }
-
-    fn pending_cleanup(&self) -> bool {
-        self.0 == 0
-    }
-}
 
 // ---------------------------------------------------------------------------
 // State – per-key state with key and pre-computed hash
@@ -73,10 +42,15 @@ impl<K, V> State<K, V> {
     ///
     /// # Note
     ///
-    /// The reference count uses 31 bits, supporting up to 2^31 concurrent references.
-    /// Overflow is not checked; exceeding this limit causes undefined behavior.
+    /// The reference count uses 31 bits, supporting up to 2^31 - 1 concurrent
+    /// references. Overflow is checked in debug builds only.
     fn inc_ref(&self) -> StateFlags {
-        StateFlags(self.flags.fetch_add(1, Ordering::AcqRel) + 1)
+        let old = self.flags.fetch_add(1, Ordering::AcqRel);
+        debug_assert!(
+            StateFlags(old).refcnt() < StateFlags::REFCNT_MASK,
+            "lockmap: reference count overflow"
+        );
+        StateFlags(old + 1)
     }
 
     fn dec_ref(&self) -> StateFlags {
@@ -130,22 +104,22 @@ impl<K, V> ShardInner<K, V> {
 // ---------------------------------------------------------------------------
 
 struct ShardMap<K, V> {
-    inner: std::sync::Mutex<ShardInner<K, V>>,
+    inner: Mutex<ShardInner<K, V>>,
 }
 
 impl<K, V> ShardMap<K, V> {
     fn with_capacity(capacity: usize) -> Self {
         Self {
-            inner: std::sync::Mutex::new(ShardInner::with_capacity(capacity)),
+            inner: Mutex::new(ShardInner::with_capacity(capacity)),
         }
     }
 
     fn len(&self) -> usize {
-        self.inner.lock().unwrap().table.len()
+        self.inner.lock().table.len()
     }
 
     fn is_empty(&self) -> bool {
-        self.inner.lock().unwrap().table.is_empty()
+        self.inner.lock().table.is_empty()
     }
 }
 
@@ -190,13 +164,6 @@ impl<K, V> ShardMap<K, V> {
 pub struct LockMap<K, V> {
     shards: Vec<ShardMap<K, V>>,
     hasher: RandomState,
-}
-
-fn default_shard_amount() -> usize {
-    static DEFAULT_SHARD_AMOUNT: OnceLock<usize> = OnceLock::new();
-    *DEFAULT_SHARD_AMOUNT.get_or_init(|| {
-        (std::thread::available_parallelism().map_or(1, usize::from) * 4).next_power_of_two()
-    })
 }
 
 impl<K: Eq + Hash, V> Default for LockMap<K, V> {
@@ -279,28 +246,55 @@ impl<K: Eq + Hash, V> LockMap<K, V> {
     /// }
     /// ```
     pub fn entry(&self, key: K) -> Entry<'_, K, V> {
+        let ptr = self.acquire_state(key);
+        self.guard(ptr)
+    }
+
+    /// Attempts to get exclusive access to an entry without blocking.
+    ///
+    /// Returns `None` if another thread currently holds the entry for this key.
+    /// Unlike [`entry`](Self::entry), this method never blocks on the per-key
+    /// lock (it may still wait briefly on the internal shard lock).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use lockmap::LockMap;
+    /// let map = LockMap::<String, u32>::new();
+    /// let entry = map.entry("key".to_string());
+    /// // The key is held by `entry`, so `try_entry` fails:
+    /// assert!(map.try_entry("key".to_string()).is_none());
+    /// drop(entry);
+    /// assert!(map.try_entry("key".to_string()).is_some());
+    /// ```
+    pub fn try_entry(&self, key: K) -> Option<Entry<'_, K, V>> {
+        let ptr = self.acquire_state(key);
+        self.try_guard(ptr)
+    }
+
+    /// Acquires (or creates) the state for `key`, incrementing its reference
+    /// count. The returned pointer is valid until released via `guard` /
+    /// `try_guard` / `release_ref`.
+    fn acquire_state(&self, key: K) -> *mut State<K, V> {
         let hash = self.hasher.hash_one(&key);
         let shard = &self.shards[self.shard_index(hash)];
-        let ptr: *mut State<K, V> = {
-            let mut inner = shard.inner.lock().unwrap();
-            match inner
-                .table
-                .entry(hash, |s| s.key.borrow() == &key, Self::state_hasher())
-            {
-                TableEntry::Occupied(occupied) => {
-                    let ptr = &**occupied.get() as *const State<K, V> as *mut State<K, V>;
-                    unsafe { &*ptr }.inc_ref();
-                    ptr
-                }
-                TableEntry::Vacant(vacant) => {
-                    let state = State::new(key, None, 1, hash);
-                    let ptr = &*state as *const State<K, V> as *mut State<K, V>;
-                    vacant.insert(state);
-                    ptr
-                }
+        let mut inner = shard.inner.lock();
+        match inner
+            .table
+            .entry(hash, |s| s.key.borrow() == &key, Self::state_hasher())
+        {
+            TableEntry::Occupied(occupied) => {
+                let ptr = &**occupied.get() as *const State<K, V> as *mut State<K, V>;
+                unsafe { &*ptr }.inc_ref();
+                ptr
             }
-        };
-        self.guard(ptr)
+            TableEntry::Vacant(vacant) => {
+                let state = State::new(key, None, 1, hash);
+                let ptr = &*state as *const State<K, V> as *mut State<K, V>;
+                vacant.insert(state);
+                ptr
+            }
+        }
     }
 
     /// Gets exclusive access to an entry by reference.
@@ -322,29 +316,61 @@ impl<K: Eq + Hash, V> LockMap<K, V> {
         K: Borrow<Q> + for<'c> From<&'c Q>,
         Q: Eq + Hash + ?Sized,
     {
+        let ptr = self.acquire_state_by_ref(key);
+        self.guard(ptr)
+    }
+
+    /// Attempts to get exclusive access to an entry by reference without blocking.
+    ///
+    /// Returns `None` if another thread currently holds the entry for this key.
+    /// Unlike [`entry_by_ref`](Self::entry_by_ref), this method never blocks on
+    /// the per-key lock (it may still wait briefly on the internal shard lock).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use lockmap::LockMap;
+    /// let map = LockMap::<String, u32>::new();
+    /// let entry = map.entry_by_ref("key");
+    /// assert!(map.try_entry_by_ref("key").is_none());
+    /// drop(entry);
+    /// assert!(map.try_entry_by_ref("key").is_some());
+    /// ```
+    pub fn try_entry_by_ref<Q>(&self, key: &Q) -> Option<Entry<'_, K, V>>
+    where
+        K: Borrow<Q> + for<'c> From<&'c Q>,
+        Q: Eq + Hash + ?Sized,
+    {
+        let ptr = self.acquire_state_by_ref(key);
+        self.try_guard(ptr)
+    }
+
+    /// By-reference variant of [`acquire_state`](Self::acquire_state).
+    fn acquire_state_by_ref<Q>(&self, key: &Q) -> *mut State<K, V>
+    where
+        K: Borrow<Q> + for<'c> From<&'c Q>,
+        Q: Eq + Hash + ?Sized,
+    {
         let hash = self.hasher.hash_one(key);
         let shard = &self.shards[self.shard_index(hash)];
-        let ptr: *mut State<K, V> = {
-            let mut inner = shard.inner.lock().unwrap();
-            match inner
-                .table
-                .entry(hash, |s| s.key.borrow() == key, Self::state_hasher())
-            {
-                TableEntry::Occupied(occupied) => {
-                    let ptr = &**occupied.get() as *const State<K, V> as *mut State<K, V>;
-                    unsafe { &*ptr }.inc_ref();
-                    ptr
-                }
-                TableEntry::Vacant(vacant) => {
-                    let owned_key: K = key.into();
-                    let state = State::new(owned_key, None, 1, hash);
-                    let ptr = &*state as *const State<K, V> as *mut State<K, V>;
-                    vacant.insert(state);
-                    ptr
-                }
+        let mut inner = shard.inner.lock();
+        match inner
+            .table
+            .entry(hash, |s| s.key.borrow() == key, Self::state_hasher())
+        {
+            TableEntry::Occupied(occupied) => {
+                let ptr = &**occupied.get() as *const State<K, V> as *mut State<K, V>;
+                unsafe { &*ptr }.inc_ref();
+                ptr
             }
-        };
-        self.guard(ptr)
+            TableEntry::Vacant(vacant) => {
+                let owned_key: K = key.into();
+                let state = State::new(owned_key, None, 1, hash);
+                let ptr = &*state as *const State<K, V> as *mut State<K, V>;
+                vacant.insert(state);
+                ptr
+            }
+        }
     }
 
     /// Gets the value associated with the given key.
@@ -382,7 +408,7 @@ impl<K: Eq + Hash, V> LockMap<K, V> {
         let mut ptr: *mut State<K, V> = std::ptr::null_mut();
 
         let value = {
-            let inner = shard.inner.lock().unwrap();
+            let inner = shard.inner.lock();
             let p = inner
                 .table
                 .find(hash, |s| s.key.borrow() == key)
@@ -427,7 +453,7 @@ impl<K: Eq + Hash, V> LockMap<K, V> {
         let hash = self.hasher.hash_one(&key);
         let shard = &self.shards[self.shard_index(hash)];
         let (ptr, old) = {
-            let mut inner = shard.inner.lock().unwrap();
+            let mut inner = shard.inner.lock();
             match inner
                 .table
                 .entry(hash, |s| s.key.borrow() == &key, Self::state_hasher())
@@ -482,7 +508,7 @@ impl<K: Eq + Hash, V> LockMap<K, V> {
         let hash = self.hasher.hash_one(key);
         let shard = &self.shards[self.shard_index(hash)];
         let (ptr, old) = {
-            let mut inner = shard.inner.lock().unwrap();
+            let mut inner = shard.inner.lock();
             match inner
                 .table
                 .entry(hash, |s| s.key.borrow() == key, Self::state_hasher())
@@ -540,7 +566,7 @@ impl<K: Eq + Hash, V> LockMap<K, V> {
         let mut ptr: *mut State<K, V> = std::ptr::null_mut();
 
         let found = {
-            let inner = shard.inner.lock().unwrap();
+            let inner = shard.inner.lock();
             let p = inner
                 .table
                 .find(hash, |s| s.key.borrow() == key)
@@ -590,7 +616,7 @@ impl<K: Eq + Hash, V> LockMap<K, V> {
         let shard = &self.shards[self.shard_index(hash)];
 
         let ptr = {
-            let mut inner = shard.inner.lock().unwrap();
+            let mut inner = shard.inner.lock();
             match inner.table.find_entry(hash, |s| s.key.borrow() == key) {
                 Ok(occupied) => {
                     let p = &**occupied.get() as *const State<K, V> as *mut State<K, V>;
@@ -654,12 +680,113 @@ impl<K: Eq + Hash, V> LockMap<K, V> {
             .collect()
     }
 
+    /// Removes all key-value pairs from the map.
+    ///
+    /// Entries that are currently held by an [`Entry`] guard are cleared by
+    /// waiting for the guard to be released, exactly as [`remove`](Self::remove)
+    /// would.
+    ///
+    /// **Locking behaviour:** Deadlock if called when holding any entry of this map.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use lockmap::LockMap;
+    ///
+    /// let map = LockMap::<String, u32>::new();
+    /// map.insert("a".to_string(), 1);
+    /// map.insert("b".to_string(), 2);
+    /// map.clear();
+    /// assert!(map.is_empty());
+    /// ```
+    pub fn clear(&self) {
+        for shard in &self.shards {
+            let mut in_use: Vec<*mut State<K, V>> = Vec::new();
+            {
+                let mut inner = shard.inner.lock();
+                inner.table.retain(|s| {
+                    if s.flags().refcnt() == 0 {
+                        // SAFETY: refcnt == 0 → no guard exists; safe to drop.
+                        false
+                    } else {
+                        s.inc_ref();
+                        in_use.push(&**s as *const State<K, V> as *mut State<K, V>);
+                        true
+                    }
+                });
+            }
+            // For in-use entries, wait for the holders and remove the values.
+            for ptr in in_use {
+                self.guard(ptr).remove();
+            }
+        }
+    }
+
     fn guard(&self, ptr: *mut State<K, V>) -> Entry<'_, K, V> {
         // SAFETY: ptr is valid (ref-counted) and stable (AliasableBox).
         unsafe { (*ptr).mutex.lock() };
         Entry {
             map: self,
             state: ptr,
+        }
+    }
+
+    fn try_guard(&self, ptr: *mut State<K, V>) -> Option<Entry<'_, K, V>> {
+        // SAFETY: ptr is valid (ref-counted) and stable (AliasableBox).
+        if unsafe { (*ptr).mutex.try_lock() } {
+            Some(Entry {
+                map: self,
+                state: ptr,
+            })
+        } else {
+            self.release_ref(ptr);
+            None
+        }
+    }
+
+    /// Releases one reference to `state`; if this was the last reference and
+    /// the entry holds no value, the entry is removed from its shard.
+    ///
+    /// The per-key mutex must NOT be held by the caller.
+    fn release_ref(&self, state: *mut State<K, V>) {
+        let state_ref = unsafe { &*state };
+
+        // CAS loop to decrement the reference count.
+        let mut current = state_ref.flags.load(Ordering::Acquire);
+        loop {
+            let flags = StateFlags(current);
+
+            // If this is the last reference and no value, proceed to cleanup.
+            if flags.refcnt() == 1 && !flags.has_value() {
+                break;
+            }
+
+            let new_flags = StateFlags::new(flags.refcnt() - 1, flags.has_value());
+            match state_ref.flags.compare_exchange_weak(
+                current,
+                new_flags.0,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return, // Not the last reference or still has value.
+                Err(actual) => current = actual,
+            }
+        }
+
+        // Acquire shard lock using the stored hash (no re-hashing).
+        let shard = &self.shards[self.shard_index(state_ref.hash)];
+        let mut inner = shard.inner.lock();
+
+        // Decrement the reference count again; cleanup if needed.
+        let final_flags = state_ref.dec_ref();
+        if final_flags.pending_cleanup() {
+            let state_ptr = state as *const State<K, V>;
+            if let Ok(entry) = inner
+                .table
+                .find_entry(state_ref.hash, |s| std::ptr::eq(&**s, state_ptr))
+            {
+                let _ = entry.remove();
+            }
         }
     }
 }
@@ -759,44 +886,9 @@ impl<K: Eq + Hash, V> Drop for Entry<'_, K, V> {
         // SAFETY: We hold the lock (acquired in guard()).
         unsafe { state_ref.mutex.unlock() };
 
-        // 3. CAS loop to decrement reference count
-        let mut current = state_ref.flags.load(Ordering::Acquire);
-        loop {
-            let flags = StateFlags(current);
-
-            // If this is the last guard and no value, proceed to cleanup
-            if flags.refcnt() == 1 && !flags.has_value() {
-                break;
-            }
-
-            let new_flags = StateFlags::new(flags.refcnt() - 1, flags.has_value());
-            match state_ref.flags.compare_exchange_weak(
-                current,
-                new_flags.0,
-                Ordering::AcqRel,
-                Ordering::Acquire,
-            ) {
-                Ok(_) => return, // Not last guard or still has value, return early
-                Err(actual) => current = actual,
-            }
-        }
-
-        // 4. Acquire shard lock using the stored hash (no re-hashing).
-        let shard_idx = self.map.shard_index(state_ref.hash);
-        let shard = &self.map.shards[shard_idx];
-        let mut inner = shard.inner.lock().unwrap();
-
-        // 5. Decrement reference count again; cleanup if needed
-        let final_flags = state_ref.dec_ref();
-        if final_flags.pending_cleanup() {
-            let state_ptr = self.state as *const State<K, V>;
-            if let Ok(entry) = inner
-                .table
-                .find_entry(state_ref.hash, |s| std::ptr::eq(&**s, state_ptr))
-            {
-                let _ = entry.remove();
-            }
-        }
+        // 3. Release the reference; removes the entry if it is the last
+        //    reference and no value is stored.
+        self.map.release_ref(self.state);
     }
 }
 
@@ -1076,7 +1168,9 @@ mod tests {
 
     #[test]
     fn test_lockmap_get_set_by_ref() {
-        let lock_map = Arc::new(LockMap::<String, u32>::with_capacity_and_shard_amount(256, 16));
+        let lock_map = Arc::new(LockMap::<String, u32>::with_capacity_and_shard_amount(
+            256, 16,
+        ));
         #[cfg(not(miri))]
         const N: usize = 1 << 18;
         #[cfg(miri)]
@@ -1183,6 +1277,97 @@ mod tests {
             counter.load(Ordering::Relaxed),
             THREADS as u32 * OPS_PER_THREAD as u32
         );
+    }
+
+    #[test]
+    fn test_lockmap_try_entry() {
+        let map = LockMap::<String, u32>::new();
+        {
+            let mut entry = map.try_entry("key".to_string()).unwrap();
+            entry.insert(1);
+            assert!(map.try_entry("key".to_string()).is_none());
+            assert!(map.try_entry_by_ref("key").is_none());
+        }
+        assert_eq!(map.get("key"), Some(1));
+        {
+            let mut entry = map.try_entry_by_ref("key").unwrap();
+            assert_eq!(entry.remove(), Some(1));
+        }
+        // A failed try_entry on a held, empty key must not leak the entry.
+        let held = map.entry("held".to_string());
+        assert!(map.try_entry("held".to_string()).is_none());
+        drop(held);
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn test_lockmap_try_entry_concurrent() {
+        let map = Arc::new(LockMap::<u32, u32>::new());
+        #[cfg(not(miri))]
+        const N: usize = 1 << 12;
+        #[cfg(miri)]
+        const N: usize = 1 << 6;
+        const M: usize = 4;
+
+        map.insert(0, 0);
+        let success = Arc::new(AtomicU32::new(0));
+
+        let threads: Vec<_> = (0..M)
+            .map(|_| {
+                let map = map.clone();
+                let success = success.clone();
+                std::thread::spawn(move || {
+                    for _ in 0..N {
+                        if let Some(mut entry) = map.try_entry(0) {
+                            *entry.get_mut().as_mut().unwrap() += 1;
+                            success.fetch_add(1, Ordering::AcqRel);
+                        }
+                    }
+                })
+            })
+            .collect();
+        threads.into_iter().for_each(|t| t.join().unwrap());
+
+        assert_eq!(map.get(&0), Some(success.load(Ordering::Acquire)));
+    }
+
+    #[test]
+    fn test_lockmap_clear() {
+        let map = LockMap::<u32, u32>::new();
+        for i in 0..100 {
+            map.insert(i, i);
+        }
+        assert_eq!(map.len(), 100);
+        map.clear();
+        assert!(map.is_empty());
+        assert_eq!(map.get(&50), None);
+
+        // Clearing an empty map is a no-op.
+        map.clear();
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn test_lockmap_clear_with_held_entry() {
+        let map = Arc::new(LockMap::<u32, u32>::new());
+        map.insert(1, 10);
+
+        let mut held = map.entry(2);
+        held.insert(20);
+
+        let cleaner = {
+            let map = map.clone();
+            std::thread::spawn(move || map.clear())
+        };
+
+        // Give the cleaner a chance to reach the held entry, then release it.
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        drop(held);
+        cleaner.join().unwrap();
+
+        assert!(map.is_empty());
+        assert_eq!(map.get(&1), None);
+        assert_eq!(map.get(&2), None);
     }
 
     #[test]

--- a/src/lru_lockmap.rs
+++ b/src/lru_lockmap.rs
@@ -1,45 +1,14 @@
+use crate::common::{default_shard_amount, StateFlags};
 use aliasable::boxed::AliasableBox;
 use foldhash::fast::RandomState;
 use hashbrown::hash_table::Entry;
 use hashbrown::HashTable;
 use parking_lot::lock_api::RawMutex as _;
-use parking_lot::RawMutex;
+use parking_lot::{Mutex, RawMutex};
 use std::borrow::Borrow;
 use std::cell::UnsafeCell;
 use std::hash::{BuildHasher, Hash};
 use std::sync::atomic::{AtomicU32, Ordering};
-use std::sync::OnceLock;
-
-// ---------------------------------------------------------------------------
-// StateFlags (same design as lockmap)
-// ---------------------------------------------------------------------------
-
-struct StateFlags(u32);
-
-impl StateFlags {
-    const HAS_VALUE_FLAG: u32 = 1 << 31;
-    const REFCNT_MASK: u32 = !Self::HAS_VALUE_FLAG;
-
-    fn new(refcnt: u32, has_value: bool) -> Self {
-        let mut val = refcnt & Self::REFCNT_MASK;
-        if has_value {
-            val |= Self::HAS_VALUE_FLAG;
-        }
-        Self(val)
-    }
-
-    fn refcnt(&self) -> u32 {
-        self.0 & Self::REFCNT_MASK
-    }
-
-    fn has_value(&self) -> bool {
-        (self.0 & Self::HAS_VALUE_FLAG) != 0
-    }
-
-    fn pending_cleanup(&self) -> bool {
-        self.0 == 0
-    }
-}
 
 // ---------------------------------------------------------------------------
 // State – per-key state with intrusive LRU list pointers
@@ -52,7 +21,7 @@ struct State<K, V> {
     mutex: RawMutex,
     value: UnsafeCell<Option<V>>,
     // Intrusive doubly-linked list pointers for LRU ordering.
-    // These are only accessed while the shard's `std::sync::Mutex` is held.
+    // These are only accessed while the shard's `parking_lot::Mutex` is held.
     prev: UnsafeCell<*mut Self>,
     next: UnsafeCell<*mut Self>,
 }
@@ -74,8 +43,19 @@ impl<K, V> State<K, V> {
         StateFlags(self.flags.load(Ordering::Acquire))
     }
 
+    /// Increments the reference count.
+    ///
+    /// # Note
+    ///
+    /// The reference count uses 31 bits, supporting up to 2^31 - 1 concurrent
+    /// references. Overflow is checked in debug builds only.
     fn inc_ref(&self) -> StateFlags {
-        StateFlags(self.flags.fetch_add(1, Ordering::AcqRel) + 1)
+        let old = self.flags.fetch_add(1, Ordering::AcqRel);
+        debug_assert!(
+            StateFlags(old).refcnt() < StateFlags::REFCNT_MASK,
+            "lockmap: reference count overflow"
+        );
+        StateFlags(old + 1)
     }
 
     fn dec_ref(&self) -> StateFlags {
@@ -125,7 +105,7 @@ struct LruShardInner<K, V> {
 }
 
 // SAFETY: The raw pointers (head, tail, prev, next) are only accessed while
-// the shard's `std::sync::Mutex` is held, ensuring exclusive access.
+// the shard's `parking_lot::Mutex` is held, ensuring exclusive access.
 unsafe impl<K: Send, V: Send> Send for LruShardInner<K, V> {}
 
 impl<K, V> LruShardInner<K, V> {
@@ -242,34 +222,34 @@ impl<K, V> LruShardInner<K, V> {
 // ---------------------------------------------------------------------------
 
 struct LruShardMap<K, V> {
-    inner: std::sync::Mutex<LruShardInner<K, V>>,
+    inner: Mutex<LruShardInner<K, V>>,
 }
 
 impl<K, V> LruShardMap<K, V> {
     fn with_capacity(max_size: usize, capacity: usize) -> Self {
         Self {
-            inner: std::sync::Mutex::new(LruShardInner::with_capacity(max_size, capacity)),
+            inner: Mutex::new(LruShardInner::with_capacity(max_size, capacity)),
         }
     }
 
     fn len(&self) -> usize {
-        self.inner.lock().unwrap().table.len()
+        self.inner.lock().table.len()
     }
 
     fn is_empty(&self) -> bool {
-        self.inner.lock().unwrap().table.is_empty()
+        self.inner.lock().table.is_empty()
     }
 
     fn max_size(&self) -> usize {
-        self.inner.lock().unwrap().max_size
+        self.inner.lock().max_size
     }
 
     fn set_max_size(&self, max_size: usize) {
-        self.inner.lock().unwrap().max_size = max_size;
+        self.inner.lock().max_size = max_size;
     }
 
     fn set_max_evict(&self, max_evict: usize) {
-        self.inner.lock().unwrap().max_evict = max_evict.max(1);
+        self.inner.lock().max_evict = max_evict.max(1);
     }
 }
 
@@ -318,13 +298,6 @@ pub struct LruLockMap<K, V> {
     hasher: RandomState,
 }
 
-fn default_shard_amount() -> usize {
-    static DEFAULT_SHARD_AMOUNT: OnceLock<usize> = OnceLock::new();
-    *DEFAULT_SHARD_AMOUNT.get_or_init(|| {
-        (std::thread::available_parallelism().map_or(1, usize::from) * 4).next_power_of_two()
-    })
-}
-
 impl<K: Eq + Hash, V> LruLockMap<K, V> {
     /// Creates a new `LruLockMap` with the given total capacity.
     ///
@@ -363,7 +336,8 @@ impl<K: Eq + Hash, V> LruLockMap<K, V> {
     /// This is the total logical capacity across all shards, computed from the
     /// per‑shard limits. The per‑shard limit is derived using
     /// `max_size.div_ceil(shard_amount)`, so the effective total capacity may be
-    /// rounded up compared to the value originally passed to [`with_options`].
+    /// rounded up compared to the value originally passed to
+    /// [`with_options`](Self::with_options).
     ///
     /// # Examples
     ///
@@ -458,33 +432,59 @@ impl<K: Eq + Hash, V> LruLockMap<K, V> {
     /// }
     /// ```
     pub fn entry(&self, key: K) -> LruEntry<'_, K, V> {
+        let ptr = self.acquire_state(key);
+        self.guard(ptr)
+    }
+
+    /// Attempts to get exclusive access to an entry without blocking.
+    ///
+    /// Returns `None` if another thread currently holds the entry for this key.
+    /// Unlike [`entry`](Self::entry), this method never blocks on the per-key
+    /// lock (it may still wait briefly on the internal shard lock). The key is
+    /// promoted in the LRU list even if `None` is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use lockmap::LruLockMap;
+    /// let cache = LruLockMap::<String, u32>::new(100);
+    /// let entry = cache.entry("key".to_string());
+    /// // The key is held by `entry`, so `try_entry` fails:
+    /// assert!(cache.try_entry("key".to_string()).is_none());
+    /// drop(entry);
+    /// assert!(cache.try_entry("key".to_string()).is_some());
+    /// ```
+    pub fn try_entry(&self, key: K) -> Option<LruEntry<'_, K, V>> {
+        let ptr = self.acquire_state(key);
+        self.try_guard(ptr)
+    }
+
+    /// Acquires (or creates) the state for `key`, incrementing its reference
+    /// count, promoting it in the LRU list and triggering eviction if needed.
+    fn acquire_state(&self, key: K) -> *mut State<K, V> {
         let hash = self.hasher.hash_one(&key);
         let shard = &self.shards[self.shard_index(hash)];
-        let ptr: *mut State<K, V> = {
-            let mut inner = shard.inner.lock().unwrap();
-            let ptr =
-                match inner
-                    .table
-                    .entry(hash, |s| s.key.borrow() == &key, Self::state_hasher())
-                {
-                    Entry::Occupied(occupied) => {
-                        let ptr = &**occupied.get() as *const State<K, V> as *mut State<K, V>;
-                        unsafe { &*ptr }.inc_ref();
-                        unsafe { inner.move_to_front(ptr) };
-                        ptr
-                    }
-                    Entry::Vacant(vacant) => {
-                        let state = State::new(key, None, 1, hash);
-                        let ptr = &*state as *const State<K, V> as *mut State<K, V>;
-                        vacant.insert(state);
-                        unsafe { inner.push_front(ptr) };
-                        ptr
-                    }
-                };
-            inner.try_evict(ptr);
-            ptr
+        let mut inner = shard.inner.lock();
+        let ptr = match inner
+            .table
+            .entry(hash, |s| s.key.borrow() == &key, Self::state_hasher())
+        {
+            Entry::Occupied(occupied) => {
+                let ptr = &**occupied.get() as *const State<K, V> as *mut State<K, V>;
+                unsafe { &*ptr }.inc_ref();
+                unsafe { inner.move_to_front(ptr) };
+                ptr
+            }
+            Entry::Vacant(vacant) => {
+                let state = State::new(key, None, 1, hash);
+                let ptr = &*state as *const State<K, V> as *mut State<K, V>;
+                vacant.insert(state);
+                unsafe { inner.push_front(ptr) };
+                ptr
+            }
         };
-        self.guard(ptr)
+        inner.try_evict(ptr);
+        ptr
     }
 
     /// Gets exclusive access to an entry by reference.
@@ -506,33 +506,66 @@ impl<K: Eq + Hash, V> LruLockMap<K, V> {
         K: Borrow<Q> + for<'c> From<&'c Q>,
         Q: Eq + Hash + ?Sized,
     {
+        let ptr = self.acquire_state_by_ref(key);
+        self.guard(ptr)
+    }
+
+    /// Attempts to get exclusive access to an entry by reference without blocking.
+    ///
+    /// Returns `None` if another thread currently holds the entry for this key.
+    /// Unlike [`entry_by_ref`](Self::entry_by_ref), this method never blocks on
+    /// the per-key lock (it may still wait briefly on the internal shard lock).
+    /// The key is promoted in the LRU list even if `None` is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use lockmap::LruLockMap;
+    /// let cache = LruLockMap::<String, u32>::new(100);
+    /// let entry = cache.entry_by_ref("key");
+    /// assert!(cache.try_entry_by_ref("key").is_none());
+    /// drop(entry);
+    /// assert!(cache.try_entry_by_ref("key").is_some());
+    /// ```
+    pub fn try_entry_by_ref<Q>(&self, key: &Q) -> Option<LruEntry<'_, K, V>>
+    where
+        K: Borrow<Q> + for<'c> From<&'c Q>,
+        Q: Eq + Hash + ?Sized,
+    {
+        let ptr = self.acquire_state_by_ref(key);
+        self.try_guard(ptr)
+    }
+
+    /// By-reference variant of [`acquire_state`](Self::acquire_state).
+    fn acquire_state_by_ref<Q>(&self, key: &Q) -> *mut State<K, V>
+    where
+        K: Borrow<Q> + for<'c> From<&'c Q>,
+        Q: Eq + Hash + ?Sized,
+    {
         let hash = self.hasher.hash_one(key);
         let shard = &self.shards[self.shard_index(hash)];
-        let ptr: *mut State<K, V> = {
-            let mut inner = shard.inner.lock().unwrap();
-            let ptr = match inner
-                .table
-                .entry(hash, |s| s.key.borrow() == key, Self::state_hasher())
-            {
-                Entry::Occupied(occupied) => {
-                    let ptr = &**occupied.get() as *const State<K, V> as *mut State<K, V>;
-                    unsafe { &*ptr }.inc_ref();
-                    unsafe { inner.move_to_front(ptr) };
-                    ptr
-                }
-                Entry::Vacant(vacant) => {
-                    let owned_key: K = key.into();
-                    let state = State::new(owned_key, None, 1, hash);
-                    let ptr = &*state as *const State<K, V> as *mut State<K, V>;
-                    vacant.insert(state);
-                    unsafe { inner.push_front(ptr) };
-                    ptr
-                }
-            };
-            inner.try_evict(ptr);
-            ptr
+        let mut inner = shard.inner.lock();
+        let ptr = match inner
+            .table
+            .entry(hash, |s| s.key.borrow() == key, Self::state_hasher())
+        {
+            Entry::Occupied(occupied) => {
+                let ptr = &**occupied.get() as *const State<K, V> as *mut State<K, V>;
+                unsafe { &*ptr }.inc_ref();
+                unsafe { inner.move_to_front(ptr) };
+                ptr
+            }
+            Entry::Vacant(vacant) => {
+                let owned_key: K = key.into();
+                let state = State::new(owned_key, None, 1, hash);
+                let ptr = &*state as *const State<K, V> as *mut State<K, V>;
+                vacant.insert(state);
+                unsafe { inner.push_front(ptr) };
+                ptr
+            }
         };
-        self.guard(ptr)
+        inner.try_evict(ptr);
+        ptr
     }
 
     /// Gets the value associated with the given key.
@@ -561,7 +594,7 @@ impl<K: Eq + Hash, V> LruLockMap<K, V> {
         let mut ptr: *mut State<K, V> = std::ptr::null_mut();
 
         let value = {
-            let mut inner = shard.inner.lock().unwrap();
+            let mut inner = shard.inner.lock();
             let p = inner
                 .table
                 .find(hash, |s| s.key.borrow() == key)
@@ -607,7 +640,7 @@ impl<K: Eq + Hash, V> LruLockMap<K, V> {
         let hash = self.hasher.hash_one(&key);
         let shard = &self.shards[self.shard_index(hash)];
         let (ptr, old) = {
-            let mut inner = shard.inner.lock().unwrap();
+            let mut inner = shard.inner.lock();
             match inner
                 .table
                 .entry(hash, |s| s.key.borrow() == &key, Self::state_hasher())
@@ -665,7 +698,7 @@ impl<K: Eq + Hash, V> LruLockMap<K, V> {
         let hash = self.hasher.hash_one(key);
         let shard = &self.shards[self.shard_index(hash)];
         let (ptr, old) = {
-            let mut inner = shard.inner.lock().unwrap();
+            let mut inner = shard.inner.lock();
             match inner
                 .table
                 .entry(hash, |s| s.key.borrow() == key, Self::state_hasher())
@@ -728,7 +761,7 @@ impl<K: Eq + Hash, V> LruLockMap<K, V> {
         let mut ptr: *mut State<K, V> = std::ptr::null_mut();
 
         let found = {
-            let mut inner = shard.inner.lock().unwrap();
+            let mut inner = shard.inner.lock();
             let p = inner
                 .table
                 .find(hash, |s| s.key.borrow() == key)
@@ -779,7 +812,7 @@ impl<K: Eq + Hash, V> LruLockMap<K, V> {
         let shard = &self.shards[self.shard_index(hash)];
 
         let ptr = {
-            let mut inner = shard.inner.lock().unwrap();
+            let mut inner = shard.inner.lock();
             let p = match inner.table.find_entry(hash, |s| s.key.borrow() == key) {
                 Ok(occupied) => {
                     let p = &**occupied.get() as *const State<K, V> as *mut State<K, V>;
@@ -803,12 +836,125 @@ impl<K: Eq + Hash, V> LruLockMap<K, V> {
         self.guard(ptr).remove()
     }
 
+    /// Removes all key-value pairs from the cache.
+    ///
+    /// Entries that are currently held by an [`LruEntry`] guard are cleared by
+    /// waiting for the guard to be released, exactly as [`remove`](Self::remove)
+    /// would.
+    ///
+    /// **Locking behaviour:** Deadlock if called when holding any entry of this cache.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use lockmap::LruLockMap;
+    /// let cache = LruLockMap::<String, u32>::new(100);
+    /// cache.insert("a".to_string(), 1);
+    /// cache.insert("b".to_string(), 2);
+    /// cache.clear();
+    /// assert!(cache.is_empty());
+    /// ```
+    pub fn clear(&self) {
+        for shard in &self.shards {
+            let mut in_use: Vec<*mut State<K, V>> = Vec::new();
+            {
+                let mut inner = shard.inner.lock();
+                let mut cursor = inner.head;
+                while !cursor.is_null() {
+                    // SAFETY: cursor is a valid node of this shard's list; the
+                    // shard mutex is held. `next` is read before any removal.
+                    let next = unsafe { *(*cursor).next.get() };
+                    let state = unsafe { &*cursor };
+                    if state.flags().refcnt() == 0 {
+                        // SAFETY: refcnt == 0 → no guard exists; safe to drop.
+                        let hash = state.hash;
+                        unsafe { inner.detach(cursor) };
+                        if let Ok(entry) =
+                            inner.table.find_entry(hash, |s| std::ptr::eq(&**s, cursor))
+                        {
+                            let _ = entry.remove();
+                        }
+                    } else {
+                        state.inc_ref();
+                        in_use.push(cursor);
+                    }
+                    cursor = next;
+                }
+            }
+            // For in-use entries, wait for the holders and remove the values.
+            for ptr in in_use {
+                self.guard(ptr).remove();
+            }
+        }
+    }
+
     fn guard(&self, ptr: *mut State<K, V>) -> LruEntry<'_, K, V> {
         // SAFETY: ptr is valid (ref-counted) and stable (AliasableBox).
         unsafe { (*ptr).mutex.lock() };
         LruEntry {
             map: self,
             state: ptr,
+        }
+    }
+
+    fn try_guard(&self, ptr: *mut State<K, V>) -> Option<LruEntry<'_, K, V>> {
+        // SAFETY: ptr is valid (ref-counted) and stable (AliasableBox).
+        if unsafe { (*ptr).mutex.try_lock() } {
+            Some(LruEntry {
+                map: self,
+                state: ptr,
+            })
+        } else {
+            self.release_ref(ptr);
+            None
+        }
+    }
+
+    /// Releases one reference to `state`; if this was the last reference and
+    /// the entry holds no value, the entry is detached from the LRU list and
+    /// removed from its shard.
+    ///
+    /// The per-key mutex must NOT be held by the caller.
+    fn release_ref(&self, state: *mut State<K, V>) {
+        let state_ref = unsafe { &*state };
+
+        // CAS loop to decrement the reference count.
+        let mut current = state_ref.flags.load(Ordering::Acquire);
+        loop {
+            let flags = StateFlags(current);
+
+            // If this is the last reference and no value, proceed to cleanup.
+            if flags.refcnt() == 1 && !flags.has_value() {
+                break;
+            }
+
+            let new_flags = StateFlags::new(flags.refcnt() - 1, flags.has_value());
+            match state_ref.flags.compare_exchange_weak(
+                current,
+                new_flags.0,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return, // Not the last reference or still has value.
+                Err(actual) => current = actual,
+            }
+        }
+
+        // Acquire shard lock using the stored hash (no re-hashing).
+        let shard = &self.shards[self.shard_index(state_ref.hash)];
+        let mut inner = shard.inner.lock();
+
+        // Decrement the reference count again; cleanup if needed.
+        let final_flags = state_ref.dec_ref();
+        if final_flags.pending_cleanup() {
+            unsafe { inner.detach(state) };
+            let state_ptr = state as *const State<K, V>;
+            if let Ok(entry) = inner
+                .table
+                .find_entry(state_ref.hash, |s| std::ptr::eq(&**s, state_ptr))
+            {
+                let _ = entry.remove();
+            }
         }
     }
 }
@@ -900,45 +1046,9 @@ impl<K: Eq + Hash, V> Drop for LruEntry<'_, K, V> {
         // SAFETY: We hold the lock (acquired in guard()).
         unsafe { state_ref.mutex.unlock() };
 
-        // 3. CAS loop to decrement reference count
-        let mut current = state_ref.flags.load(Ordering::Acquire);
-        loop {
-            let flags = StateFlags(current);
-
-            // If this is the last guard and no value, proceed to cleanup
-            if flags.refcnt() == 1 && !flags.has_value() {
-                break;
-            }
-
-            let new_flags = StateFlags::new(flags.refcnt() - 1, flags.has_value());
-            match state_ref.flags.compare_exchange_weak(
-                current,
-                new_flags.0,
-                Ordering::AcqRel,
-                Ordering::Acquire,
-            ) {
-                Ok(_) => return, // Not last guard or still has value, return early
-                Err(actual) => current = actual,
-            }
-        }
-
-        // 4. Acquire shard lock using the stored hash (no re-hashing).
-        let shard_idx = self.map.shard_index(state_ref.hash);
-        let shard = &self.map.shards[shard_idx];
-        let mut inner = shard.inner.lock().unwrap();
-
-        // 5. Decrement reference count again; cleanup if needed
-        let final_flags = state_ref.dec_ref();
-        if final_flags.pending_cleanup() {
-            unsafe { inner.detach(self.state) };
-            let state_ptr = self.state as *const State<K, V>;
-            if let Ok(entry) = inner
-                .table
-                .find_entry(state_ref.hash, |s| std::ptr::eq(&**s, state_ptr))
-            {
-                let _ = entry.remove();
-            }
-        }
+        // 3. Release the reference; detaches and removes the entry if it is
+        //    the last reference and no value is stored.
+        self.map.release_ref(self.state);
     }
 }
 
@@ -1755,5 +1865,91 @@ mod tests {
         assert!(cache.get(&3).is_some());
         assert!(cache.get(&4).is_some());
         assert_eq!(cache.get(&5), Some(50));
+    }
+
+    // --- try_entry / clear ---
+
+    #[test]
+    fn test_lru_try_entry() {
+        let cache = LruLockMap::<String, u32>::new(100);
+        {
+            let mut entry = cache.try_entry("key".to_string()).unwrap();
+            entry.insert(1);
+            assert!(cache.try_entry("key".to_string()).is_none());
+            assert!(cache.try_entry_by_ref("key").is_none());
+        }
+        assert_eq!(cache.get("key"), Some(1));
+        {
+            let mut entry = cache.try_entry_by_ref("key").unwrap();
+            assert_eq!(entry.remove(), Some(1));
+        }
+        // A failed try_entry on a held, empty key must not leak the entry.
+        let held = cache.entry("held".to_string());
+        assert!(cache.try_entry("held".to_string()).is_none());
+        drop(held);
+        assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn test_lru_try_entry_promotes() {
+        let cache = LruLockMap::<u32, u32>::with_options(3, 3, 1);
+        cache.insert(1, 10);
+        cache.insert(2, 20);
+        cache.insert(3, 30);
+
+        // Promote key=1 via try_entry.
+        assert!(cache.try_entry(1).is_some());
+
+        cache.insert(4, 40);
+        assert_eq!(cache.get(&2), None); // evicted
+        assert_eq!(cache.get(&1), Some(10)); // promoted
+    }
+
+    #[test]
+    fn test_lru_clear() {
+        let cache = LruLockMap::<u32, u32>::with_options(3, 3, 1);
+        cache.insert(1, 10);
+        cache.insert(2, 20);
+        cache.insert(3, 30);
+        cache.clear();
+        assert!(cache.is_empty());
+
+        // The LRU list must remain consistent after clear: eviction still works.
+        cache.insert(4, 40);
+        cache.insert(5, 50);
+        cache.insert(6, 60);
+        cache.insert(7, 70);
+        assert_eq!(cache.len(), 3);
+        assert_eq!(cache.get(&4), None); // evicted
+        assert_eq!(cache.get(&5), Some(50));
+        assert_eq!(cache.get(&6), Some(60));
+        assert_eq!(cache.get(&7), Some(70));
+
+        // Clearing an empty cache is a no-op.
+        cache.clear();
+        assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn test_lru_clear_with_held_entry() {
+        let cache = Arc::new(LruLockMap::<u32, u32>::new(100));
+        cache.insert(1, 10);
+
+        let mut held = cache.entry(2);
+        held.insert(20);
+
+        let cleaner = {
+            let cache = cache.clone();
+            std::thread::spawn(move || cache.clear())
+        };
+
+        // Give the cleaner a chance to reach the held entry, then release it.
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        drop(held);
+        cleaner.join().unwrap();
+
+        assert!(cache.is_empty());
+        assert_eq!(cache.get(&1), None);
+        assert_eq!(cache.get(&2), None);
     }
 }


### PR DESCRIPTION
- Add non-blocking try_entry/try_entry_by_ref and clear() to LockMap and LruLockMap
- Switch shard locks from std::sync::Mutex to parking_lot::Mutex to avoid poisoning a shard when V::clone() panics inside get()
- Extract shared internals (StateFlags, default_shard_amount) into src/common.rs and deduplicate guard release logic into release_ref()
- Check refcnt overflow with debug_assert in inc_ref
- Attach README doctests via the #[cfg(doctest)] idiom
- CI: add fmt+clippy lint job; run Miri on the whole library test suite
- Cargo.toml: declare rust-version 1.75, keywords/categories/readme; pin dev-deps
- Docs: link CHANGELOG.md from README, fix broken intra-doc link