### PR TITLE
release: bump version to 0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.3] - 2026-07-16
 
 ### Added
 
@@ -158,6 +158,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Iterative interface optimizations across multiple releases (#3, #4, #6, #7)
 - Performance improvements to the core locking implementation (#5)
 
+[0.2.3]: https://github.com/SF-Zhou/lockmap/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/SF-Zhou/lockmap/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/SF-Zhou/lockmap/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/SF-Zhou/lockmap/compare/v0.1.16...v0.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lockmap"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 rust-version = "1.75"
 


### PR DESCRIPTION
Finalize the changelog: rename Unreleased to 0.2.3 (2026-07-16) and add the compare link. All changes since 0.2.2 are additive or internal; no breaking changes.